### PR TITLE
Expose `strokeDash` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ import { AnimatedGaugeProgress, GaugeProgress } from 'react-native-simple-gauge'
   cropDegree={90}
   tintColor="#4682b4"
   backgroundColor="#b0c4de"
+  stroke={[2, 2]} //For a equaly dashed line
   strokeCap="circle" />
 ```  
 

--- a/src/CircularProgress.js
+++ b/src/CircularProgress.js
@@ -25,7 +25,7 @@ export default class CircularProgress extends React.Component {
   }
 
   render() {
-    const { size, width, tintColor, backgroundColor, style, strokeCap, rotation, cropDegree, children } = this.props;
+    const { size, width, tintColor, backgroundColor, style, stroke, strokeCap, rotation, cropDegree, children } = this.props;
     const backgroundPath = this.circlePath(size / 2, size / 2, size / 2 - width / 2, 0, (360 * 99.9 / 100) - cropDegree);
 
     const fill = this.extractFill(this.props.fill);
@@ -38,10 +38,12 @@ export default class CircularProgress extends React.Component {
           height={size}>
           <Group rotation={rotation + cropDegree/2} originX={size/2} originY={size/2}>
             <Shape d={backgroundPath}
+                   strokeDash={stroke}
                    stroke={backgroundColor}
                    strokeWidth={width}
                    strokeCap={strokeCap}/>
             <Shape d={circlePath}
+                   strokeDash={stroke}
                    stroke={tintColor}
                    strokeWidth={width}
                    strokeCap={strokeCap}/>
@@ -61,6 +63,7 @@ CircularProgress.propTypes = {
   fill: PropTypes.number.isRequired,
   width: PropTypes.number.isRequired,
   tintColor: PropTypes.string,
+  stroke: PropTypes.arrayOf(PropTypes.number),
   strokeCap: PropTypes.string,
   backgroundColor: PropTypes.string,
   rotation: PropTypes.number,


### PR DESCRIPTION
This PR add a `stroke` property that is an array of numbers that describe the stroke used to draw the circles.

As described in the documentation for `CGContextSetLineDash`:

> The array specify the lengths of the painted segments and unpainted segments, respectively, of the dash pattern.  For example, passing an array with the values [2,3] sets a dash pattern that alternates between a 2-user-space-unit-long painted segment and a 3-user-space-unit-long unpainted segment. Passing the values [1,3,4,2] sets the pattern to a 1-unit painted segment, a 3-unit unpainted segment, a 4-unit painted segment, and a 2-unit unpainted segment.

| Value: [2, 2] | Value: [2, 4, 2] |
|-------------|-------------|
| ![screen shot 2017-11-30 at 14 28 08](https://user-images.githubusercontent.com/3342380/33435974-8d6d77d4-d5db-11e7-9ee0-4f8a73de2fef.png) | ![screen shot 2017-11-30 at 14 27 52](https://user-images.githubusercontent.com/3342380/33435975-8da28672-d5db-11e7-8e81-efad7163d1f2.png) |
