### PR TITLE
Updated to use extracted Art component

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ RN 0.60+
 * RN <= 0.44 supported by 0.1.2
 
 ## Install  
+#RN 0.62+
+1) `npm i --save react-native-simple-gauge`
+2) `npm i --save @react-native-community/art`
+3) run `pod install` in `ios` directory
+
+#RN 0.60 - 0.61
 1) `npm i --save react-native-simple-gauge`  
 2) Link the ART library to your ReactNative project for ios
 add below line to `ios/Podfile`

--- a/src/GaugeProgress.js
+++ b/src/GaugeProgress.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { View, Platform, ViewPropTypes, AppState } from 'react-native';
-import { Surface, Shape, Path, Group } from '../../react-native/Libraries/ART/ReactNativeART';
+import { Surface, Shape, Path, Group } from '@react-native-community/art';
 import MetricsPath from 'art/metrics/path';
 const ActiveState = "active"
 


### PR DESCRIPTION
In React Native 0.62 Art was extracted out of react-native to https://github.com/react-native-community/art.

This package now works with React native 0.62+ when you install @react-native-community/art to your project as well.