### PR TITLE
Fix warning of missing useNativeDriver; defaults to false

### DIFF
--- a/src/AnimatedGaugeProgress.js
+++ b/src/AnimatedGaugeProgress.js
@@ -31,7 +31,7 @@ export default class AnimatedGaugeProgress extends React.Component {
   }
 
   animateFill() {
-    const { tension, friction, onAnimationComplete, prefill } = this.props;
+    const { tension, friction, onAnimationComplete, prefill, useNativeDriver } = this.props;
 
     var chartFillAnimation = new Animated.Value(prefill || 0)
     this.setState({chartFillAnimation})
@@ -41,7 +41,8 @@ export default class AnimatedGaugeProgress extends React.Component {
       {
         toValue: this.props.fill,
         tension,
-        friction
+        friction,
+        useNativeDriver,
       }
     ).start(onAnimationComplete);
   }
@@ -68,11 +69,13 @@ AnimatedGaugeProgress.propTypes = {
   backgroundColor: PropTypes.string,
   tension: PropTypes.number,
   friction: PropTypes.number,
+  useNativeDriver: PropTypes.bool,
   onAnimationComplete: PropTypes.func,
   onLinearAnimationComplete: PropTypes.func,
 }
 
 AnimatedGaugeProgress.defaultProps = {
   tension: 7,
-  friction: 10
+  friction: 10,
+  useNativeDriver: false,
 };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -27,6 +27,7 @@ type AnimatedGaugeProgressProps = GaugeProgressProps & {
   prefill?: number;
   tension?: number;
   friction?: number;
+  useNativeDriver?: boolean;
   onAnimationComplete?: (callback: { finished: boolean }) => void;
 };
 type AnimatedGaugeProgressState = {


### PR DESCRIPTION
With upgrading to RN 0.63 - I experienced that when rendering an AnimatedGauge the warning that "useNativeDriver" was missing. This PR should fix the issue.