### PR TITLE
fix: AppState.removeEventListener is undefined

### DIFF
--- a/src/AnimatedGaugeProgress.js
+++ b/src/AnimatedGaugeProgress.js
@@ -13,11 +13,11 @@ export default class AnimatedGaugeProgress extends React.Component {
 
   componentDidMount() { 
     this.animateFill();
-    AppState.addEventListener('change', this._handleAppStateChange);
+    this.subscription = AppState.addEventListener('change', this._handleAppStateChange);
   }
 
   componentWillUnmount() {
-    AppState.removeEventListener('change', this._handleAppStateChange);
+    this.subscription.remove()
   }
 
   _handleAppStateChange = (nextAppState) => {


### PR DESCRIPTION
Fix this TypeError:` _reactNative.AppState.removeEventListener is not a function (it is undefined)`